### PR TITLE
Added addons for neuroc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,15 @@ r_check_args: --as-cran
 
 r:
   - release
-  
+
+addons:
+  apt:
+    packages:
+    - tk 
+    - tk-dev
+    - tcl 
+    - tcl-dev
+
 # env:
 #   global:
 #   - _R_CHECK_FORCE_SUGGESTS_=FALSE

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,16 @@ language: R
 sudo: false
 cache: packages
 
-env:
-  global:
-  - _R_CHECK_FORCE_SUGGESTS_=FALSE
-  - MAKEFLAGS="-j 2"
+warnings_are_errors: true
+
+bioc_required: yes
+use_bioc: yes
+r_check_args: --as-cran
+
+r:
+  - release
+  
+# env:
+#   global:
+#   - _R_CHECK_FORCE_SUGGESTS_=FALSE
+#   - MAKEFLAGS="-j 2"

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,3 +47,4 @@ Suggests:
     rmarkdown
 VignetteBuilder:
     knitr
+


### PR DESCRIPTION
I checked this against travis while adding tcl/tk for `tkrplot`, and it should now pass Neuroconductor checks: https://travis-ci.org/muschellij2/spant.  Please merge, bump the version (e.g. 9001) and resubmit to neuroconductor.

Thanks